### PR TITLE
Use Event.composedPath() instead of Event.path in specification-viewer Web Component

### DIFF
--- a/oas-data-viewer-web-component/index.html
+++ b/oas-data-viewer-web-component/index.html
@@ -104,7 +104,7 @@
 
       function onVersionClick(event){
         console.log('onVersionClick', event);
-        const version = event.path[0];
+        const version = event.composedPath()[0];
         const viewer = document.querySelector('specification-viewer');
         const dataFile = '../specifications-data/'+version.textContent+'.json';
         console.log('data file', dataFile);

--- a/oas-data-viewer-web-component/specification-viewer.js
+++ b/oas-data-viewer-web-component/specification-viewer.js
@@ -692,7 +692,7 @@ class SpecificationViewer extends HTMLElement {
   }
 
   onclick(event) {
-    const elementClicked = event.path[0];
+    const elementClicked = event.composedPath()[0];
     const dataAction = elementClicked.getAttribute('data-action');
     if(dataAction == 'children'){
       this.showHideChildren(elementClicked);


### PR DESCRIPTION
`Event.path` is non-standard and breaks in certain browsers like Firefox.  `Event.composedPath()` is cross-browser compatible.